### PR TITLE
fix: bad soundcloud url parse when secret link

### DIFF
--- a/jukebot/components/result.py
+++ b/jukebot/components/result.py
@@ -40,7 +40,11 @@ class Result:
                 # ? Remove metadata from url
                 self.web_url = self.web_url.split("?")[0]
 
-            *_, tmp_channel, tmp_title = self.web_url.split("/")
+            # ? should give [https, "" (because of double slash), soundlouc, channel, title, secret (if exist)]
+            data = self.web_url.split("/")
+            data = data[3:]  # ? we remove the 3 first element (https, "", soundcloud.com)
+            tmp_channel: str = data[0]  # ? we keep channel
+            tmp_title: str = data[1]  # ? and title
             if self.channel == "Unknown":
                 self.channel = tmp_channel.replace("-", " ").title()
             if self.title == "Unknown":

--- a/tests/test_music_request.py
+++ b/tests/test_music_request.py
@@ -291,28 +291,6 @@ class TestMusicRequestComponent(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.live)
         self.assertIsNone(result.requester)
 
-    async def test_music_request_success_soundcloud_shorted_url_convert_to_result(self):
-        with disable_logging():
-            async with MusicRequest("https://on.soundcloud.com/Gsdzc") as req:
-                await req.execute()
-
-        self.assertTrue(req.success)
-        self.assertIsNotNone(req.result)
-        self.assertEqual(req.type, MusicRequest.ResultType.TRACK)
-
-        result: Result = Result(req.result)
-
-        self.assertEqual(result.title, "Headband Andy Vito Bad Boy")
-        self.assertEqual(result.channel, "Minecraft Pukaj 009 Sk")
-        self.assertEqual(
-            result.web_url,
-            "https://soundcloud.com/minecraft-pukaj-009-sk/headband-andy-vito-bad-boy",
-        )
-        self.assertEqual(result.duration, 0)
-        self.assertEqual(result.fmt_duration, "ထ")
-        self.assertTrue(result.live)
-        self.assertIsNone(result.requester)
-
     async def test_music_request_youtube_live_url_convert_to_result(self):
         with disable_logging():
             async with MusicRequest("https://www.youtube.com/watch?v=MVPTGNGiI-4") as req:
@@ -475,3 +453,46 @@ class TestMusicRequestComponent(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.duration, 0)
         self.assertEqual(result.fmt_duration, "ထ")
         self.assertTrue(result.live)
+
+    async def test_music_request_success_soundcloud_shorted_url_convert_to_result(self):
+        with disable_logging():
+            async with MusicRequest("https://on.soundcloud.com/Gsdzc") as req:
+                await req.execute()
+
+        self.assertTrue(req.success)
+        self.assertIsNotNone(req.result)
+        self.assertEqual(req.type, MusicRequest.ResultType.TRACK)
+
+        result: Result = Result(req.result)
+
+        self.assertEqual(result.title, "Headband Andy Vito Bad Boy")
+        self.assertEqual(result.channel, "Minecraft Pukaj 009 Sk")
+        self.assertEqual(
+            result.web_url,
+            "https://soundcloud.com/minecraft-pukaj-009-sk/headband-andy-vito-bad-boy",
+        )
+        self.assertEqual(result.duration, 0)
+        self.assertEqual(result.fmt_duration, "ထ")
+        self.assertTrue(result.live)
+        self.assertIsNone(result.requester)
+
+    async def test_music_request_success_soundcloud_shorted_private_url_convert_to_result(self):
+        async with MusicRequest("https://on.soundcloud.com/gA4Ca") as req:
+            await req.execute()
+
+        self.assertTrue(req.success)
+        self.assertIsNotNone(req.result)
+        self.assertEqual(req.type, MusicRequest.ResultType.TRACK)
+
+        result: Result = Result(req.result)
+
+        self.assertEqual(result.title, "Empty")
+        self.assertEqual(result.channel, "Dysta")
+        self.assertEqual(
+            result.web_url,
+            "https://soundcloud.com/dysta/empty/s-wEHdWGqgDdf",
+        )
+        self.assertEqual(result.duration, 0)
+        self.assertEqual(result.fmt_duration, "ထ")
+        self.assertTrue(result.live)
+        self.assertIsNone(result.requester)


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? Does it fix any issues? -->
This PR fix the bad parsing of Secret Soundcloud shorten URL


## Checklist
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue (#74).
- [ ] This PR adds something new (e.g. new feature/methods).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
